### PR TITLE
Add user repository and SQLite implementation

### DIFF
--- a/src/login_app/domain/__init__.py
+++ b/src/login_app/domain/__init__.py
@@ -1,5 +1,6 @@
 """Domain layer initialization."""
 
 from .models.user import User
+from .repositories.user_repository import UserRepository
 
-__all__ = ["User"]
+__all__ = ["User", "UserRepository"]

--- a/src/login_app/domain/repositories/__init__.py
+++ b/src/login_app/domain/repositories/__init__.py
@@ -1,0 +1,5 @@
+"""Domain repository package."""
+
+from .user_repository import UserRepository
+
+__all__ = ["UserRepository"]

--- a/src/login_app/domain/repositories/user_repository.py
+++ b/src/login_app/domain/repositories/user_repository.py
@@ -1,0 +1,20 @@
+"""User repository interface."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from ..models import User
+
+
+class UserRepository(Protocol):
+    """Interface for user persistence operations."""
+
+    def create(self, username: str, email: str, password_hash: str) -> User:
+        """Persist a new user and return the created entity."""
+
+    def get_by_id(self, user_id: int) -> User | None:
+        """Return a user by its id."""
+
+    def get_by_email(self, email: str) -> User | None:
+        """Return a user by its email address."""

--- a/src/login_app/infrastructure/__init__.py
+++ b/src/login_app/infrastructure/__init__.py
@@ -1,0 +1,6 @@
+"""Infrastructure layer initialization."""
+
+from .database import get_connection, init_db
+from .sqlite_user_repository import SQLiteUserRepository
+
+__all__ = ["SQLiteUserRepository", "get_connection", "init_db"]

--- a/src/login_app/infrastructure/sqlite_user_repository.py
+++ b/src/login_app/infrastructure/sqlite_user_repository.py
@@ -1,0 +1,70 @@
+"""SQLite implementation of the user repository."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from login_app.domain.models import User
+from login_app.domain.repositories import UserRepository
+
+from .database import DB_PATH, get_connection
+
+
+class SQLiteUserRepository(UserRepository):
+    """Repository that persists users in a SQLite database."""
+
+    def __init__(self, db_path: Path | str = DB_PATH) -> None:
+        self.db_path = Path(db_path)
+
+    def create(self, username: str, email: str, password_hash: str) -> User:
+        now = datetime.utcnow()
+        query = (
+            "INSERT INTO user (username, email, password_hash, created_at, updated_at)"
+            " VALUES (?, ?, ?, ?, ?)"
+        )
+        with get_connection(self.db_path) as conn:
+            cursor = conn.execute(query, (username, email, password_hash, now, now))
+            conn.commit()
+            user_id = cursor.lastrowid
+        return User(
+            id=user_id,
+            username=username,
+            email=email,
+            password_hash=password_hash,
+            created_at=now,
+            updated_at=now,
+        )
+
+    def _row_to_user(self, row: tuple[Any, ...]) -> User:
+        return User(
+            id=row[0],
+            username=row[1],
+            email=row[2],
+            password_hash=row[3],
+            created_at=datetime.fromisoformat(row[4]),
+            updated_at=datetime.fromisoformat(row[5]),
+        )
+
+    def get_by_id(self, user_id: int) -> User | None:
+        query = (
+            "SELECT id, username, email, password_hash, created_at, updated_at"
+            " FROM user WHERE id = ?"
+        )
+        with get_connection(self.db_path) as conn:
+            row = conn.execute(query, (user_id,)).fetchone()
+        if row is None:
+            return None
+        return self._row_to_user(row)
+
+    def get_by_email(self, email: str) -> User | None:
+        query = (
+            "SELECT id, username, email, password_hash, created_at, updated_at"
+            " FROM user WHERE email = ?"
+        )
+        with get_connection(self.db_path) as conn:
+            row = conn.execute(query, (email,)).fetchone()
+        if row is None:
+            return None
+        return self._row_to_user(row)

--- a/tests/unit/test_sqlite_user_repository.py
+++ b/tests/unit/test_sqlite_user_repository.py
@@ -1,0 +1,23 @@
+from login_app.infrastructure.database import init_db
+from login_app.infrastructure.sqlite_user_repository import SQLiteUserRepository
+
+
+def test_create_and_get_by_email(tmp_path):
+    db_file = tmp_path / "test.db"
+    init_db(db_file)
+    repo = SQLiteUserRepository(db_file)
+
+    user = repo.create("alice", "alice@example.com", "hash")
+    assert user.id is not None
+    fetched = repo.get_by_email("alice@example.com")
+    assert fetched == user
+
+
+def test_get_by_id(tmp_path):
+    db_file = tmp_path / "test.db"
+    init_db(db_file)
+    repo = SQLiteUserRepository(db_file)
+
+    user = repo.create("bob", "bob@example.com", "hash")
+    fetched = repo.get_by_id(user.id)
+    assert fetched == user


### PR DESCRIPTION
## Summary
- add `UserRepository` interface for persisting and searching users
- export `UserRepository` from domain layer
- provide `SQLiteUserRepository` infrastructure class
- expose new infrastructure utilities
- add unit tests for the SQLite repository

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*