### PR TITLE
Add auth usecase with password strength checks

### DIFF
--- a/src/login_app/usecases/__init__.py
+++ b/src/login_app/usecases/__init__.py
@@ -1,0 +1,5 @@
+"""Application use cases."""
+
+from .auth_usecase import AuthUsecase
+
+__all__ = ["AuthUsecase"]

--- a/src/login_app/usecases/auth_usecase.py
+++ b/src/login_app/usecases/auth_usecase.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Use case layer for authentication."""
+
+import re
+from typing import Any, MutableMapping
+
+from login_app.domain.repositories import UserRepository
+from login_app.infrastructure.security.password import hash_password, verify_password
+
+
+class AuthUsecase:
+    """Provide user registration, login and logout operations."""
+
+    def __init__(self, user_repo: UserRepository) -> None:
+        self.user_repo = user_repo
+
+    def _check_strength(self, password: str) -> None:
+        """Validate password strength and raise ValueError if weak."""
+        if len(password) < 8:
+            raise ValueError("Password must be at least 8 characters long")
+        if not re.search(r"[A-Z]", password):
+            raise ValueError("Password must include an uppercase letter")
+        if not re.search(r"[a-z]", password):
+            raise ValueError("Password must include a lowercase letter")
+        if not re.search(r"\d", password):
+            raise ValueError("Password must include a digit")
+
+    def register(self, username: str, email: str, password: str):
+        """Create a new user after validating password strength."""
+        self._check_strength(password)
+        hashed = hash_password(password)
+        return self.user_repo.create(username, email, hashed)
+
+    def login(self, email: str, password: str):
+        """Authenticate a user by email and password."""
+        user = self.user_repo.get_by_email(email)
+        if user is None or not verify_password(password, user.password_hash):
+            raise ValueError("Invalid credentials")
+        return user
+
+    def logout(self, session: MutableMapping[str, Any]) -> None:
+        """Remove user information from the given session."""
+        session.pop("user_id", None)

--- a/tests/unit/test_auth_usecase.py
+++ b/tests/unit/test_auth_usecase.py
@@ -1,0 +1,39 @@
+import pytest
+
+from login_app.infrastructure.database import init_db
+from login_app.infrastructure.sqlite_user_repository import SQLiteUserRepository
+from login_app.usecases import AuthUsecase
+
+
+def setup_usecase(tmp_path):
+    db = tmp_path / "test.db"
+    init_db(db)
+    repo = SQLiteUserRepository(db)
+    return AuthUsecase(repo)
+
+
+def test_register_and_login(tmp_path):
+    uc = setup_usecase(tmp_path)
+    user = uc.register("alice", "alice@example.com", "Strong123")
+    logged_in = uc.login("alice@example.com", "Strong123")
+    assert logged_in == user
+
+
+def test_register_weak_password(tmp_path):
+    uc = setup_usecase(tmp_path)
+    with pytest.raises(ValueError):
+        uc.register("bob", "bob@example.com", "weak")
+
+
+def test_login_invalid_password(tmp_path):
+    uc = setup_usecase(tmp_path)
+    uc.register("carol", "carol@example.com", "Strong123")
+    with pytest.raises(ValueError):
+        uc.login("carol@example.com", "wrong")
+
+
+def test_logout():
+    uc = AuthUsecase(None)  # type: ignore
+    session = {"user_id": 1}
+    uc.logout(session)
+    assert "user_id" not in session


### PR DESCRIPTION
## Summary
- create usecases layer and implement `AuthUsecase`
- add password strength validation during registration
- expose `AuthUsecase` through package init
- add unit tests for register/login/logout behavior

## Testing
- `isort . && black .` *(passed)*
- `flake8` *(failed: command not found)*
- `pytest -q` *(failed: command not found)*
