### PR TITLE
Add Flask app factory and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,6 @@ jobs:
       - name: Lint
         run: flake8
       - name: Test
-        run: pytest
+        run: |
+          pytest --cov=login_app --cov-report=term-missing:skip-covered \
+            --cov-fail-under=80

--- a/src/login_app/__init__.py
+++ b/src/login_app/__init__.py
@@ -1,0 +1,5 @@
+"""Login application package."""
+
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/src/login_app/app.py
+++ b/src/login_app/app.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Flask application factory."""
+
+from pathlib import Path
+
+from flask import Flask
+
+from .infrastructure.database import DB_PATH, init_db
+from .infrastructure.sqlite_user_repository import SQLiteUserRepository
+from .interface.session import init_session
+from .interfaces.controllers.auth_controller import create_auth_blueprint
+from .interfaces.controllers.dashboard_controller import create_dashboard_blueprint
+from .usecases import AuthUsecase
+
+
+def create_app(db_path: Path | str = DB_PATH) -> Flask:
+    """Create and configure the Flask application."""
+    app = Flask(__name__)
+    app.config.setdefault("SECRET_KEY", "dev-secret")
+    init_session(app)
+    init_db(db_path)
+    user_repo = SQLiteUserRepository(db_path)
+    auth_uc = AuthUsecase(user_repo)
+    app.register_blueprint(create_auth_blueprint(auth_uc))
+    app.register_blueprint(create_dashboard_blueprint(user_repo))
+    return app

--- a/src/login_app/interface/session.py
+++ b/src/login_app/interface/session.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import secrets
+
 from flask import Flask, abort, request, session
 
 

--- a/tests/integration/test_endpoints.py
+++ b/tests/integration/test_endpoints.py
@@ -1,0 +1,81 @@
+import re
+
+import pytest
+
+from login_app.app import create_app
+
+
+@pytest.fixture()
+def client(tmp_path):
+    db = tmp_path / "test.db"
+    app = create_app(db)
+    app.config.update(TESTING=True)
+    with app.test_client() as client:
+        yield client
+
+
+def _set_csrf(client, token="test-token"):
+    with client.session_transaction() as sess:
+        sess["csrf_token"] = token
+    return token
+
+
+def test_register_login_logout_flow(client):
+    token = _set_csrf(client)
+    resp = client.post(
+        "/register",
+        data={
+            "username": "alice",
+            "email": "alice@example.com",
+            "password": "Strong123",
+            "csrf_token": token,
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/login")
+
+    token = _set_csrf(client)
+    resp = client.post(
+        "/login",
+        data={
+            "email": "alice@example.com",
+            "password": "Strong123",
+            "csrf_token": token,
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/dashboard")
+
+    dashboard = client.get("/dashboard")
+    assert dashboard.status_code == 200
+    assert re.search(b"alice", dashboard.data)
+
+    token = _set_csrf(client)
+    resp = client.post("/logout", data={"csrf_token": token}, follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/login")
+    dash_resp = client.get("/dashboard")
+    assert dash_resp.status_code == 302
+
+
+def test_register_weak_password(client):
+    token = _set_csrf(client)
+    resp = client.post(
+        "/register",
+        data={
+            "username": "bob",
+            "email": "bob@example.com",
+            "password": "weak",
+            "csrf_token": token,
+        },
+    )
+    assert resp.status_code == 200
+    assert b"Password" in resp.data
+
+
+def test_dashboard_requires_login(client):
+    resp = client.get("/dashboard")
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/login")


### PR DESCRIPTION
## Summary
- implement Flask app factory
- export `create_app`
- add endpoint integration tests with CSRF handling
- enforce coverage in CI workflow

## Testing
- `black .`
- `isort .`
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*